### PR TITLE
Added some stuff to make it possible to just apply a sitewide schema

### DIFF
--- a/code/extensions/MetadataExtension.php
+++ b/code/extensions/MetadataExtension.php
@@ -103,8 +103,11 @@ class MetadataExtension extends DataObjectDecorator {
 				null,
 				'INNER JOIN "MetadataSchemaLink" ON ' . $filter
 			);
+			if (!$result) {
+				$result = new DataObjectSet();
+			}
 		}
-		
+
 		if ($this->owner instanceof SiteTree) {
 			// Check SiteConfig too
 			$config = SiteConfig::current_site_config();


### PR DESCRIPTION
FEATURE: Metadata schemas applied to SiteTree content will now look up to SiteConfig for inherited schemas (if the extension is applied to SiteConfig)
