### PR TITLE
Metadata output changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,28 @@
 
 ## Requirements
 * SilverStripe 3+
-* SortableGridField - https://github.com/UndefinedOffset/SortableGridField
+* The SilverStripe Orderable module.
+
+## Getting started
+
+* Add the extension to your data class, eg `Object::add_extension('Page', 'MetadataExtension');`
+* Navigate to the Metadata section of the CMS (/admin/metadata)
+* Create a new Metadata Schema. Note that the 'Title' is what is used to refer to the item from templates, so try and 
+  limit this to a-z0-9_-. characters - eg test_schema
+* Add a few metadata fields - some usual ones are
+  * Title (title)
+  * Keywords (keywords)
+  * Description (description)
+* Set the 'Default' value for each of these to $Title. Leave the 'cascade' setting blank for now, as you're providing
+  a default already
+* Navigate to a top level page and on its Metadata tab, select the schema you just created; click save
+* Enter metadata values
+* In your Page.ss template, add the following to output all metadata fields
+  * `$MetadataMetaTags` 
+* To output just the values for a particular applied schema, use
+  * `$MetadataMetaTags(SchemaName)`
+* To access raw metadata values directly, use
+  * `$Metadata(SchemaName,FieldName)` eg `$Metadata(test_schema,keywords)`
 
 ## Project Links
 * [GitHub Project Page](https://github.com/ajshort/silverstripe-metadata)

--- a/code/formfields/MetadataSetField.php
+++ b/code/formfields/MetadataSetField.php
@@ -113,6 +113,7 @@ class MetadataSetField extends FormField {
 			}
 
 			$result->push(new ArrayData(array(
+				'Link'		  => Controller::join_links('admin/metadata/MetadataSchema/EditForm/field/MetadataSchema/item', $schema->ID, 'edit'),
 				'Title'       => $schema->Title,
 				'Description' => $schema->Description,
 				'Fields'      => $fields

--- a/css/MetadataSetField.css
+++ b/css/MetadataSetField.css
@@ -1,6 +1,5 @@
 .MetadataSetField h3 a {
-	padding: 5px 5px 5px 25px !important;
-	font-size: 12px !important;
+	font-size: 14px !important;
 }
 
 .MetadataSetField .ui-accordion-content {

--- a/javascript/MetadataSetField.js
+++ b/javascript/MetadataSetField.js
@@ -4,15 +4,16 @@
 		
 		$("#Form_EditForm .ss-metdatasetfield").entwine({
 			onmatch: function() {
-				this.accordion({
-					collapsible: true,
-					active: false
-				});
+//				This is commented out for now as we don't really need the accordion control 
+//				this.accordion({
+//					collapsible: true,
+//					active: false
+//				});
 
 				this._super();
 			},
 			onremove: function() {
-				this.accordion('destroy');
+//				this.accordion('destroy');
 			},
 
 			getTabSet: function() {
@@ -21,7 +22,7 @@
 
 			fromTabSet: {
 				ontabsshow: function() {
-					this.accordion("resize");
+					// this.accordion("resize");
 				}
 			}
 

--- a/templates/MetadataSetField.ss
+++ b/templates/MetadataSetField.ss
@@ -2,7 +2,7 @@
 	<% if Schemas %>
 		<div id="$ID" class="ss-metdatasetfield">
 			<% control Schemas %>
-				<h3><a href="#">$Title</a></h3>
+				<h3><a href="$Link">$Title</a></h3>
 				<div>
 					<% if Description %>
 						<p class="ss-metadatasetfield-description">$Description</p>


### PR DESCRIPTION
- $MetadataMetaTags can now be called to output all applied schemas + values
- Removed need for accordion field that was breaking in SS3 backend
- Linked metadata on object to metadata schema management interface
- Updated basic documentation
