### PR TITLE
Add support for data objects not inheriting from SiteTree

### DIFF
--- a/code/extensions/MetadataExtension.php
+++ b/code/extensions/MetadataExtension.php
@@ -312,6 +312,16 @@ class MetadataExtension extends DataExtension
         return $result;
     }
     
+    public function updateCMSFields(FieldList $fields)
+    {
+        // instance of SiteTree uses updateSettingsFields hook
+        if ($this->owner instanceof SiteTree) {
+            return;
+        }
+
+        $this->updateSettingsFields($fields);
+    }
+
     public function updateSettingsFields(FieldList $fields)
     {
         if ($this->owner->ID <= 0) {


### PR DESCRIPTION
When the data object the extension is applied to doesn't inherit from SiteTree, the updateSettingsFields hook is not available and the whole set of fields is not accessible.

This affects e.g. pages created via DataObject-as-Page module.

Calling the function from updateCMSFields creates a new tab as expected, just next to the Main content tab, not under settings, which is a minor difference.